### PR TITLE
fix: don't modify download dir permission when writeable

### DIFF
--- a/rootfs/etc/cont-init.d/58-permissions
+++ b/rootfs/etc/cont-init.d/58-permissions
@@ -20,7 +20,7 @@ if [[ -z ${PUID} && -z ${PGID} ]] || [[ ${PUID} = 65534 && ${PGID} = 65534 ]]; t
     chmod -v 777 ${DOWNLOAD_DIR}
     chmod -vR 777 ${ARIA2_CONF_DIR}
 else
-    chmod -v u=rwx ${DOWNLOAD_DIR}
+    if [ -w ${DOWNLOAD_DIR} ]; then echo "Download DIR writeable, not modifying permission."; else chmod -v u=rwx ${DOWNLOAD_DIR}; fi
     chmod -v 600 ${ARIA2_CONF_DIR}/*
     chmod -v 755 ${SCRIPT_DIR}
     chmod -v 700 ${SCRIPT_DIR}/*

--- a/rootfs/etc/cont-init.d/58-permissions
+++ b/rootfs/etc/cont-init.d/58-permissions
@@ -13,7 +13,7 @@
 # See /LICENSE for more information.
 
 . /etc/init-base
-chown -R p3terx:p3terx ${DOWNLOAD_DIR}
+if [ -w ${DOWNLOAD_DIR} ]; then echo "Download DIR writeable, not changing owner."; else chown -R p3terx:p3terx ${DOWNLOAD_DIR}; fi
 chown -R p3terx:p3terx ${ARIA2_CONF_DIR}
 if [[ -z ${PUID} && -z ${PGID} ]] || [[ ${PUID} = 65534 && ${PGID} = 65534 ]]; then
     echo -e "${WARN} Ignore permission settings."


### PR DESCRIPTION
On complicated environments, the download folder is shared by multi-users on different devices using different protocols like smb and nfs. Under these conditions simply overwrite the permission would break the settings explicitly set by the server administrator. We should not change the folder permission if we can already write into this directory as the "permission fix" behavior is to help amateur users who don't know how to properly set permission after all.